### PR TITLE
mac: Fix building on macOS 14.

### DIFF
--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -11,7 +11,7 @@
 #include <assert.h>
 
 #include "AvailabilityMacros.h"
-#ifndef MAC_OS_VERSION_12_0
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 #define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
 #endif
 


### PR DESCRIPTION
MAC_OS_VERSION_12_0 is not defined in macOS 14.
The fix uses MAC_OS_X_VERSION_MIN_REQUIRED for version checks.